### PR TITLE
blockchain connector with Basic Auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.10 AS build
+WORKDIR /go/src/app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build connector.go
+
+FROM ubuntu:16.04 AS ca-store
+RUN apt-get update -y
+RUN apt-get install -y ca-certificates curl
+RUN update-ca-certificates -v
+RUN curl -s "http://www.microsoft.com/pki/mscorp/msitwww2(1).crt" > cert.crt && openssl x509 -in cert.crt -inform DER -out pem.pem -outform PEM && cat pem.pem >> /etc/ssl/certs/ca-certificates.crt
+RUN curl -s http://www.microsoft.com/pki/mscorp/Microsoft%20IT%20TLS%20CA%201.crt > cert.crt && openssl x509 -in cert.crt -inform DER -out pem.pem -outform PEM && cat pem.pem >> /etc/ssl/certs/ca-certificates.crt
+RUN curl -s http://www.microsoft.com/pki/mscorp/Microsoft%20IT%20TLS%20CA%202.crt > cert.crt && openssl x509 -in cert.crt -inform DER -out pem.pem -outform PEM && cat pem.pem >> /etc/ssl/certs/ca-certificates.crt
+RUN curl -s http://www.microsoft.com/pki/mscorp/Microsoft%20IT%20TLS%20CA%204.crt > cert.crt && openssl x509 -in cert.crt -inform DER -out pem.pem -outform PEM && cat pem.pem >> /etc/ssl/certs/ca-certificates.crt
+RUN curl -s http://www.microsoft.com/pki/mscorp/Microsoft%20IT%20TLS%20CA%205.crt > cert.crt && openssl x509 -in cert.crt -inform DER -out pem.pem -outform PEM && cat pem.pem >> /etc/ssl/certs/ca-certificates.crt
+
+FROM scratch
+COPY --from=ca-store /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /go/src/app/connector /bin/connector
+ENTRYPOINT ["connector", "-cert", "/etc/ssl/certs/ca-certificates.crt"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,93 @@
+# Blockchain Connector
+
+This is a proxy for you to connect to the blockchain safely. We provide three ways for you to use it: 
+
+    - Compile our source code (implement with golang) and run it.
+    
+    - Run it in Docker Container, with the Dockerfile we presented in this branch. 
+    
+    - Run with the binary release (not available yet).
+
+## Run with the Source Code
+
+1. Get the environment of golang ready.
+
+2. 
+```bash
+go get github.com/Microsoft/azure-blockchain-connector/tree/basic_auth
+```
+
+3. In the project directory, run
+```bash
+go build -o <outputFile> HttpProxy.go
+```
+
+where \<outputFile\> is the name of the executable file you want to specify with, "HttpProxy" if not specified.
+
+4. 
+```bash
+./<outputFile>  <parameters>
+```
+where \<parameters\> is the parameters needed by the program. To know about the parameters in detail, see the section "Parameters". 
+
+## Run with the Dockerfile
+
+1. Get the environment for Docker.
+
+2. Clone or download this repo to anywhere you like (If you clone it, please make sure to check out to the brunch "basic_auth").
+
+3. Run in the project directory
+```bash
+docker build -t <image_name> .
+```
+where \<image_name\> is the name of the output image.
+
+4. 
+```bash
+docker run --net=host --name=<container_name> <image_name> <parameters>
+```
+where <container_name> is the name of the container you are to run, and \<parameters\> are the parameters of the entrypoint (which essentially are the parameters of the golang code). To know about the parameters in detail, see the section "Parameters".
+
+## Parameters
+
+1. parameters:
+
+   - **username** *string*
+
+            The username you want to login with (no default).
+
+   - **password** *string*
+
+            The password you want to login with (no default).
+
+   - **local** *string*
+
+            Local address to bind to (default "127.0.0.1:3100"). Note that local address can be non-local, But if so, you should make sure the connection from your computer to the "local address" is safe (e.g. the connection is in a LAN).
+
+   - **remote** *string*
+
+           The host you want to send to (no default).
+
+2. example for users who run with our source code:
+
+   ```bash
+   ./<outputFile> -username user -password 12345 -remote https://microsoft.com/ -local 127.0.0.1:3100 
+   ```
+
+3. examples for users who run with Docker
+    ```bash
+   docker run --net=host --name=<container_name> <image_name> -username user -password 12345 -remote https://microsoft.com/ -local 127.0.0.1:3100 
+   ```
+
+4. If you want to use this connector to test your environment, but you only have a self-signed SSL certificate, the parameters below may help you:
+  
+   - **cert** *string*
+
+            The CA cert of your self-signed certificate.
+
+   - **insecure** *bool*
+
+            Indicating if it should skip certificate verifications.
 
 # Contributing
 

--- a/connector.go
+++ b/connector.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+)
+
+const defaultLocal = "127.0.0.1:3100"
+
+type proxyParams struct {
+	local, remote                string
+	username, password, certPath string
+	insecure                     bool
+	pool                         *x509.CertPool
+	client                       *http.Client
+}
+
+type proxyHandler struct {
+	params *proxyParams
+}
+
+func (handler proxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	var params = handler.params
+	req.URL.Scheme = "https"
+	req.URL.Host = params.remote
+	req.Host = ""
+	req.RequestURI = ""
+	req.Header.Set("Accept-Encoding", "identity")
+	req.SetBasicAuth(params.username, params.password)
+
+	fmt.Println("Requesting:", req.Method, req.URL)
+
+	// do request and get response
+	var response, err = params.client.Do(req)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer response.Body.Close()
+	rw.WriteHeader(response.StatusCode)
+	io.Copy(rw, response.Body)
+}
+
+func initParameter(params *proxyParams) {
+	flag.StringVar(&params.local, "local", "", "Local address to bind to")
+	flag.StringVar(&params.remote, "remote", "", "Remote endpoint address")
+	flag.StringVar(&params.username, "username", "", "The username you want to login with")
+	flag.StringVar(&params.password, "password", "", "The password you want to login with")
+	flag.StringVar(&params.certPath, "cert", "", "(Optional) File path to root CA")
+	flag.BoolVar(&params.insecure, "insecure", false, "Skip certificate verifications")
+	flag.Parse()
+
+	if params.local == "" {
+		params.local = defaultLocal
+	}
+
+	if params.remote == "" || params.username == "" || params.password == "" {
+		flag.Usage()
+		os.Exit(-1)
+	}
+}
+
+func initCACert(params *proxyParams) {
+	var caCertPath = params.certPath
+	if caCertPath != "" {
+		caCrt, err := ioutil.ReadFile(caCertPath)
+		if err != nil {
+			fmt.Println("ReadFile err:", err)
+			return
+		}
+		params.pool.AppendCertsFromPEM(caCrt)
+	}
+}
+
+func initHttpClient(params *proxyParams) {
+	params.pool = x509.NewCertPool()
+	initCACert(params)
+
+	// client setting
+	var tp = http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            params.pool,
+			InsecureSkipVerify: params.insecure,
+		},
+		MaxIdleConnsPerHost: 1024,
+	}
+	params.client = &http.Client{Transport: &tp}
+}
+
+func testConnection(params *proxyParams) {
+	req, err := http.NewRequest(http.MethodGet, "https://"+params.remote, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	req.SetBasicAuth(params.username, params.password)
+	res, err := params.client.Do(req)
+	if err != nil {
+		fmt.Println("Error occurred when sending test request to the remote host:")
+		fmt.Println(err)
+		fmt.Println("Please check your Internet connection and the remote host address.")
+		os.Exit(-2)
+	}
+	if res.StatusCode == 401 {
+		fmt.Println("Unable to pass the authentication on the remote server. Please Check your username and password.")
+		os.Exit(-2)
+	}
+
+}
+
+func main() {
+	var cancellation = make(chan os.Signal)
+	var params = proxyParams{}
+	initParameter(&params)
+	initHttpClient(&params)
+	testConnection(&params)
+	fmt.Println("The request will be transport to: " + params.remote)
+	fmt.Println("Listen on " + params.local)
+	if err := http.ListenAndServe(params.local, proxyHandler{params: &params}); err != nil {
+		fmt.Println("Error on listening: ", err)
+		os.Exit(-2)
+	} else {
+		fmt.Println("Connector started")
+	}
+
+	signal.Notify(cancellation, os.Interrupt)
+	<-cancellation
+	fmt.Println("Cancelling...")
+}


### PR DESCRIPTION
A proxy to wrap the requests to blockchain nodes with HTTPS and Basic Auth
- add a feature: checking before initiating the proxy, to avoid connection error and 401.
- fix a bug: now the client can get the HTTP status code correctly,